### PR TITLE
update_laabl_rpc(): remove unneeded command substitution

### DIFF
--- a/applications/luci-app-adblock-lean/root/usr/libexec/rpcd/luci.adblock-lean
+++ b/applications/luci-app-adblock-lean/root/usr/libexec/rpcd/luci.adblock-lean
@@ -222,7 +222,7 @@ update_laabl_rpc() {
 	uclient-fetch "$url" -O "/tmp/luci-app-adblock-lean-latest.ipk" 1> /dev/null 2> "/tmp/luci-app-adblock-lean-fetch.err"
 	if grep -q "Download completed" "/tmp/luci-app-adblock-lean-fetch.err"
 	then
-		$(opkg install "/tmp/luci-app-adblock-lean-latest.ipk")
+		opkg install "/tmp/luci-app-adblock-lean-latest.ipk"
 		update_result="$?"
 		service rpcd reload
 	else


### PR DESCRIPTION
This line:
`$(opkg install "/tmp/luci-app-adblock-lean-latest.ipk")`
first executes the enclosed `opkg` command and then tries to execute the output of that command - which is most likely not by design.

This PR removes execution of the output.